### PR TITLE
Update label for sending a release to 'Send Release'

### DIFF
--- a/Ghostlines.roboFontExt/info.plist
+++ b/Ghostlines.roboFontExt/info.plist
@@ -24,7 +24,7 @@
 	<key>name</key>
 	<string>Ghostlines (Beta)</string>
 	<key>timeStamp</key>
-	<real>1475530436.782804</real>
+	<real>1476319914.718644</real>
 	<key>version</key>
 	<string>0.2.1</string>
 </dict>

--- a/Ghostlines.roboFontExt/lib/ghostlines/windows/ufo_delivery_window.py
+++ b/Ghostlines.roboFontExt/lib/ghostlines/windows/ufo_delivery_window.py
@@ -26,7 +26,7 @@ class UFODeliveryWindow(BaseWindowController):
 
         self.window.background = Background((0, 0, -0, 48))
         self.window.attribution = AttributionText((15, 15, -15, 22), font)
-        self.window.send_button = Button((-135, 12, 120, 24), "Deliver", callback=self.send)
+        self.window.send_button = Button((-135, 12, 120, 24), "Send Release", callback=self.send)
 
         self.window.recipients = List((-285, 65, 270, -49), self.recipients)
         self.window.add_recipient_button = Button((-285, -39, 30, 24), "+", callback=self.add_recipient)

--- a/src/lib/ghostlines/windows/ufo_delivery_window.py
+++ b/src/lib/ghostlines/windows/ufo_delivery_window.py
@@ -26,7 +26,7 @@ class UFODeliveryWindow(BaseWindowController):
 
         self.window.background = Background((0, 0, -0, 48))
         self.window.attribution = AttributionText((15, 15, -15, 22), font)
-        self.window.send_button = Button((-135, 12, 120, 24), "Deliver", callback=self.send)
+        self.window.send_button = Button((-135, 12, 120, 24), "Send Release", callback=self.send)
 
         self.window.recipients = List((-285, 65, 270, -49), self.recipients)
         self.window.add_recipient_button = Button((-285, -39, 30, 24), "+", callback=self.add_recipient)


### PR DESCRIPTION
Closes #8. Just changes the label to something that makes more sense and uses a domain-related term.
