### PR TITLE
Update all Ghostlines URLs to use https

### DIFF
--- a/Ghostlines.roboFontExt/.env
+++ b/Ghostlines.roboFontExt/.env
@@ -1,4 +1,4 @@
 [ghostlines]
 environment: production
-api_url: http://www.ghostlines.pm
+api_url: https://www.ghostlines.pm
 log_level: WARNING

--- a/Ghostlines.roboFontExt/info.plist
+++ b/Ghostlines.roboFontExt/info.plist
@@ -14,7 +14,7 @@
 	<key>developer</key>
 	<string>Ghostlines</string>
 	<key>developerURL</key>
-	<string>http://ghostlines.pm</string>
+	<string>https://ghostlines.pm</string>
 	<key>html</key>
 	<true/>
 	<key>launchAtStartUp</key>
@@ -24,7 +24,7 @@
 	<key>name</key>
 	<string>Ghostlines (Beta)</string>
 	<key>timeStamp</key>
-	<real>1481314164.6547358</real>
+	<real>1483045729.360049</real>
 	<key>version</key>
 	<string>0.3.1</string>
 </dict>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ghostlines
 
-The extension for [the platform](http://ghostlines.pm). Currently in super-alpha-many-features-to-build-still stages of development.
+The extension for [the platform](https://ghostlines.pm). Currently in super-alpha-many-features-to-build-still stages of development.
 
 Please read this blog post for a short introduction to Ghostlines the extension, and the aspirations for Ghostlines the platform: https://medium.com/@ghostlines_pm/what-is-ghostlines-bdd9536c8509#.1s5lwmxkr
 

--- a/src/info.yml
+++ b/src/info.yml
@@ -2,7 +2,7 @@
 name: Ghostlines (Beta)
 version: 0.3.1
 developer: Ghostlines
-developerURL: http://ghostlines.pm
+developerURL: https://ghostlines.pm
 com.robofontmechanic.Mechanic:
   repository: ghostlines/ghostlines-robofont
   summary: Integrated project management for type design


### PR DESCRIPTION
As ghostlines is forcing the use of SSL everywhere now, this should be updated to avoid redirects.